### PR TITLE
Liam eda2

### DIFF
--- a/data.dvc
+++ b/data.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 8db5573f40a22f1433f790977dbf2dd4.dir
-  size: 98606128
+- md5: f005939f4105abbfcf54dbcf8f76dbe4.dir
+  size: 98604701
   nfiles: 27
   path: data

--- a/data.dvc
+++ b/data.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: f005939f4105abbfcf54dbcf8f76dbe4.dir
-  size: 98604701
-  nfiles: 27
+- md5: 6be6cd8666595e2ca54eca1abccc9be4.dir
+  size: 103286949
+  nfiles: 28
   path: data

--- a/data.dvc
+++ b/data.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 6be6cd8666595e2ca54eca1abccc9be4.dir
-  size: 103286949
+- md5: 47185d00bcc1987d2394e2ad647bc682.dir
+  size: 103128013
   nfiles: 28
   path: data

--- a/notebooks/liam-eda.ipynb
+++ b/notebooks/liam-eda.ipynb
@@ -2,14 +2,222 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
-    ""
+    "import pandas as pd"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "p = '/Users/liam/PycharmProjects/dataspell/artemis/data/processed/whois_data.csv'"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/s4/04m6jmt93ll3w72t198n3k3c0000gn/T/ipykernel_76438/838500597.py:1: DtypeWarning: Columns (54,105,106,107,108,109,110,114,115,116,117,118,119,120,121,123,124,125,126,127,128,129,130,134,140,141,143,145,147,148,149,150,153,154,155,156,157,159,160,161,162,166,170,171,173,174,175,176,177,178) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  df = pd.read_csv(p)\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = pd.read_csv(p)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "domain             False\nredacted           False\ncountry             True\ncreation_date_1     True\ncreation_date_2     True\n                   ...  \ndns_rec_a_cc       False\ndns_rec_a_org      False\ndns_rec_mx_cc      False\ndns_rec_mx_org     False\nmalicious          False\nLength: 185, dtype: bool"
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.isnull().any()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "Empty DataFrame\nColumns: [domain, redacted, country, creation_date_1, creation_date_2, dnssec, domain_name, emails_1, emails_2, expiration_date_1, expiration_date_2, name_servers_1, name_servers_2, name_servers_3, name_servers_4, name_servers_5, name_servers_6, name_servers_7, name_servers_8, org, registrar, state, status_1, status_2, status_3, status_4, status_5, status_6, status_7, status_8, status_9, status_10, status_11, status_12, updated_date, whois_server, address, city, creation_date, expiration_date, name, zipcode, emails_3, name_servers_9, name_servers_10, name_servers_11, name_servers_12, name_servers_13, name_servers_14, updated_date_1, updated_date_2, name_servers_15, name_servers_16, emails_4, name_servers_17, emails, name_servers, status, domain__id, registrant_country, registrant_name, registrant_state_province, registrar_id, registrar_url, admin, admin_application_purpose, admin_city, admin_country, admin_email, admin_id, admin_nexus_category, admin_organization, admin_phone, admin_postal_code, admin_state_province, admin_street, registrant_application_purpose, registrant_city, registrant_email, registrant_id, registrant_nexus_category, registrant_organization, registrant_phone, registrant_postal_code, registrant_street, registrar_email, registrar_phone, tech_application_purpose, tech_city, tech_country, tech_email, tech_id, tech_name, tech_nexus_category, tech_organization, tech_phone, tech_postal_code, tech_state_province, tech_street, registrant_type, ...]\nIndex: []\n\n[0 rows x 185 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>domain</th>\n      <th>redacted</th>\n      <th>country</th>\n      <th>creation_date_1</th>\n      <th>creation_date_2</th>\n      <th>dnssec</th>\n      <th>domain_name</th>\n      <th>emails_1</th>\n      <th>emails_2</th>\n      <th>expiration_date_1</th>\n      <th>...</th>\n      <th>tech</th>\n      <th>referral_url</th>\n      <th>registrar_site</th>\n      <th>emails_7</th>\n      <th>entropy</th>\n      <th>dns_rec_a_cc</th>\n      <th>dns_rec_a_org</th>\n      <th>dns_rec_mx_cc</th>\n      <th>dns_rec_mx_org</th>\n      <th>malicious</th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n<p>0 rows × 185 columns</p>\n</div>"
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[df.country.isnull()]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "                       domain  redacted country      creation_date_1  \\\n0                  google.com     False      US  1997-09-15 04:00:00   \n1                facebook.com     False      US                  NaN   \n2                 youtube.com     False      US                  NaN   \n3                 twitter.com     False      US  2000-01-21 16:28:17   \n4               instagram.com     False      US                  NaN   \n...                       ...       ...     ...                  ...   \n6505             ewakyc72.top      True      RU  2021-07-19 06:40:33   \n6506             ewazqx71.top      True      RU  2021-07-19 06:40:35   \n6507      rebornx.duckdns.org      True      FR                  NaN   \n6508  mail.dipiluminacion.com     False      MX  2016-07-24 19:18:34   \n6509   tzitziklishop.ddns.net     False      US  2001-06-28 16:04:59   \n\n                creation_date_2             dnssec  \\\n0           1997-09-15 07:00:00           unsigned   \n1                           NaN           unsigned   \n2                           NaN           unsigned   \n3           2000-01-21 11:28:17           unsigned   \n4                           NaN           unsigned   \n...                         ...                ...   \n6505        2021-07-18 16:00:00           unsigned   \n6506        2021-07-18 16:00:00           unsigned   \n6507                        NaN  unsigned;Unsigned   \n6508  2016-07-24 14:18:33-05:00           unsigned   \n6509  2001-06-28 16:04:59+00:00           unsigned   \n\n                                domain_name  \\\n0                     GOOGLE.COM;google.com   \n1                              FACEBOOK.COM   \n2                   YOUTUBE.COM;youtube.com   \n3                   TWITTER.COM;twitter.com   \n4                             INSTAGRAM.COM   \n...                                     ...   \n6505                           ewakyc72.top   \n6506                           ewazqx71.top   \n6507                DUCKDNS.ORG;duckdns.org   \n6508  DIPILUMINACION.COM;dipiluminacion.com   \n6509                               DDNS.NET   \n\n                               emails_1  \\\n0       abusecomplaints@markmonitor.com   \n1     abusecomplaints@registrarsafe.com   \n2       abusecomplaints@markmonitor.com   \n3             domainabuse@cscglobal.com   \n4     abusecomplaints@registrarsafe.com   \n...                                 ...   \n6505                                NaN   \n6506                                NaN   \n6507            abuse@support.gandi.net   \n6508                      abuso@akky.mx   \n6509                     abuse@noip.com   \n\n                                               emails_2    expiration_date_1  \\\n0                          whoisrequest@markmonitor.com  2028-09-14 04:00:00   \n1                                         domain@fb.com                  NaN   \n2                          whoisrequest@markmonitor.com  2023-02-15 05:13:12   \n3                                   domains@twitter.com                  NaN   \n4                                         domain@fb.com                  NaN   \n...                                                 ...                  ...   \n6505                                                NaN  2022-07-19 06:40:33   \n6506                                                NaN  2022-07-19 06:40:35   \n6507  25e6a5dc339baa71337fd929254287e6-1702436@conta...                  NaN   \n6508                                      abuse@akky.mx  2022-07-24 19:18:34   \n6509                                  domains@no-ip.com  2025-06-28 16:04:59   \n\n      ... tech referral_url registrar_site emails_7   entropy dns_rec_a_cc  \\\n0     ...  NaN          NaN            NaN      NaN  1.918296           us   \n1     ...  NaN          NaN            NaN      NaN  2.750000           us   \n2     ...  NaN          NaN            NaN      NaN  2.521641           us   \n3     ...  NaN          NaN            NaN      NaN  2.128085           us   \n4     ...  NaN          NaN            NaN      NaN  2.947703           us   \n...   ...  ...          ...            ...      ...       ...          ...   \n6505  ...  NaN          NaN            NaN      NaN  3.000000           na   \n6506  ...  NaN          NaN            NaN      NaN  3.000000           na   \n6507  ...  NaN          NaN            NaN      NaN  3.378783           nl   \n6508  ...  NaN          NaN            NaN      NaN  3.080501           us   \n6509  ...  NaN          NaN            NaN      NaN  3.337175           na   \n\n                 dns_rec_a_org dns_rec_mx_cc            dns_rec_mx_org  \\\n0                   google llc            us                google llc   \n1               facebook, inc.            us            facebook, inc.   \n2                   google llc            us                google llc   \n3                 twitter inc.            us                google llc   \n4               facebook, inc.            us          proofpoint, inc.   \n...                        ...           ...                       ...   \n6505                        na            na                        na   \n6506                        na            na                        na   \n6507  stop the war in ukraine!            nl  stop the war in ukraine!   \n6508         digitalocean, llc            us              psinet, inc.   \n6509                        na            na                        na   \n\n     malicious  \n0        False  \n1        False  \n2        False  \n3        False  \n4        False  \n...        ...  \n6505      True  \n6506      True  \n6507      True  \n6508      True  \n6509      True  \n\n[4582 rows x 185 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>domain</th>\n      <th>redacted</th>\n      <th>country</th>\n      <th>creation_date_1</th>\n      <th>creation_date_2</th>\n      <th>dnssec</th>\n      <th>domain_name</th>\n      <th>emails_1</th>\n      <th>emails_2</th>\n      <th>expiration_date_1</th>\n      <th>...</th>\n      <th>tech</th>\n      <th>referral_url</th>\n      <th>registrar_site</th>\n      <th>emails_7</th>\n      <th>entropy</th>\n      <th>dns_rec_a_cc</th>\n      <th>dns_rec_a_org</th>\n      <th>dns_rec_mx_cc</th>\n      <th>dns_rec_mx_org</th>\n      <th>malicious</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>google.com</td>\n      <td>False</td>\n      <td>US</td>\n      <td>1997-09-15 04:00:00</td>\n      <td>1997-09-15 07:00:00</td>\n      <td>unsigned</td>\n      <td>GOOGLE.COM;google.com</td>\n      <td>abusecomplaints@markmonitor.com</td>\n      <td>whoisrequest@markmonitor.com</td>\n      <td>2028-09-14 04:00:00</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>1.918296</td>\n      <td>us</td>\n      <td>google llc</td>\n      <td>us</td>\n      <td>google llc</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>facebook.com</td>\n      <td>False</td>\n      <td>US</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned</td>\n      <td>FACEBOOK.COM</td>\n      <td>abusecomplaints@registrarsafe.com</td>\n      <td>domain@fb.com</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.750000</td>\n      <td>us</td>\n      <td>facebook, inc.</td>\n      <td>us</td>\n      <td>facebook, inc.</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>youtube.com</td>\n      <td>False</td>\n      <td>US</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned</td>\n      <td>YOUTUBE.COM;youtube.com</td>\n      <td>abusecomplaints@markmonitor.com</td>\n      <td>whoisrequest@markmonitor.com</td>\n      <td>2023-02-15 05:13:12</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.521641</td>\n      <td>us</td>\n      <td>google llc</td>\n      <td>us</td>\n      <td>google llc</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>twitter.com</td>\n      <td>False</td>\n      <td>US</td>\n      <td>2000-01-21 16:28:17</td>\n      <td>2000-01-21 11:28:17</td>\n      <td>unsigned</td>\n      <td>TWITTER.COM;twitter.com</td>\n      <td>domainabuse@cscglobal.com</td>\n      <td>domains@twitter.com</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.128085</td>\n      <td>us</td>\n      <td>twitter inc.</td>\n      <td>us</td>\n      <td>google llc</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>instagram.com</td>\n      <td>False</td>\n      <td>US</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned</td>\n      <td>INSTAGRAM.COM</td>\n      <td>abusecomplaints@registrarsafe.com</td>\n      <td>domain@fb.com</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.947703</td>\n      <td>us</td>\n      <td>facebook, inc.</td>\n      <td>us</td>\n      <td>proofpoint, inc.</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>6505</th>\n      <td>ewakyc72.top</td>\n      <td>True</td>\n      <td>RU</td>\n      <td>2021-07-19 06:40:33</td>\n      <td>2021-07-18 16:00:00</td>\n      <td>unsigned</td>\n      <td>ewakyc72.top</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2022-07-19 06:40:33</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>3.000000</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>6506</th>\n      <td>ewazqx71.top</td>\n      <td>True</td>\n      <td>RU</td>\n      <td>2021-07-19 06:40:35</td>\n      <td>2021-07-18 16:00:00</td>\n      <td>unsigned</td>\n      <td>ewazqx71.top</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2022-07-19 06:40:35</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>3.000000</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>6507</th>\n      <td>rebornx.duckdns.org</td>\n      <td>True</td>\n      <td>FR</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned;Unsigned</td>\n      <td>DUCKDNS.ORG;duckdns.org</td>\n      <td>abuse@support.gandi.net</td>\n      <td>25e6a5dc339baa71337fd929254287e6-1702436@conta...</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>3.378783</td>\n      <td>nl</td>\n      <td>stop the war in ukraine!</td>\n      <td>nl</td>\n      <td>stop the war in ukraine!</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>6508</th>\n      <td>mail.dipiluminacion.com</td>\n      <td>False</td>\n      <td>MX</td>\n      <td>2016-07-24 19:18:34</td>\n      <td>2016-07-24 14:18:33-05:00</td>\n      <td>unsigned</td>\n      <td>DIPILUMINACION.COM;dipiluminacion.com</td>\n      <td>abuso@akky.mx</td>\n      <td>abuse@akky.mx</td>\n      <td>2022-07-24 19:18:34</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>3.080501</td>\n      <td>us</td>\n      <td>digitalocean, llc</td>\n      <td>us</td>\n      <td>psinet, inc.</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>6509</th>\n      <td>tzitziklishop.ddns.net</td>\n      <td>False</td>\n      <td>US</td>\n      <td>2001-06-28 16:04:59</td>\n      <td>2001-06-28 16:04:59+00:00</td>\n      <td>unsigned</td>\n      <td>DDNS.NET</td>\n      <td>abuse@noip.com</td>\n      <td>domains@no-ip.com</td>\n      <td>2025-06-28 16:04:59</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>3.337175</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>True</td>\n    </tr>\n  </tbody>\n</table>\n<p>4582 rows × 185 columns</p>\n</div>"
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[df.country.notnull()]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array(['US', 'ZZ', 'GB', 'CN', 'DE', 'SE', 'CA', 'RU', 'UK', 'CH', 'NO',\n       'IL', 'NL', 'KY', 'IS', 'AU', 'FR', 'IE', 'NZ', 'HK', 'BE', 'DK',\n       'IT', 'CA;IT', 'ES', 'PL', 'JP', 'IN', 'REDACTED FOR PRIVACY',\n       'NP', 'FI', 'BR', 'LV', 'AT', 'AUSTRIA', 'LT', 'SG', 'CY', 'BR;FR',\n       'CA;GB', 'VG', 'RO', 'CZ', 'CA;US', 'US;FR', 'MT', 'US;AU', 'DM',\n       'UNITED STATES OF AMERICA (THE)', 'UA', 'AE', 'AUSTRIA;GERMANY',\n       'EE', 'ZA', 'CA;NL', 'BG', 'BZ', 'TW', 'PA', 'TC', 'LU', 'SK',\n       'PT', 'FR;CH', 'KR', 'TH', 'AR', 'CO', 'US;US', 'BB', 'MY',\n       '108-8001', 'PH', 'KN', 'BY', 'BS', 'MALAYSIA',\n       'PERSONAL DATA, CAN NOT BE PUBLICLY DISCLOSED ACCORDING TO APPLICABLE LAWS.',\n       'ARMENIA', 'NETHERLANDS (THE)', 'SC', 'CA;KN', 'KZ', 'BRAZIL',\n       'RUSSIAN FEDERATION (THE)', 'PORTUGAL', 'KOREA (THE REPUBLIC OF)',\n       'MD', 'NG', 'JO', 'VU', 'AD', 'VI', 'BH', 'GERMANY', 'SPAIN',\n       'FINLAND', 'MX'], dtype=object)"
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.country.unique()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "             domain  redacted country creation_date_1 creation_date_2  \\\n434  altervista.org      True   CA;IT             NaN             NaN   \n\n       dnssec     domain_name                emails_1  \\\n434  unsigned  ALTERVISTA.ORG  domainabuse@tucows.com   \n\n                        emails_2 expiration_date_1  ... tech referral_url  \\\n434  abuse_reports@altervista.it               NaN  ...  NaN          NaN   \n\n    registrar_site emails_7   entropy dns_rec_a_cc  \\\n434            NaN      NaN  2.921928           de   \n\n                          dns_rec_a_org dns_rec_mx_cc  \\\n434  hetzner online gmbh - contact role            de   \n\n                         dns_rec_mx_org malicious  \n434  hetzner online gmbh - contact role     False  \n\n[1 rows x 185 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>domain</th>\n      <th>redacted</th>\n      <th>country</th>\n      <th>creation_date_1</th>\n      <th>creation_date_2</th>\n      <th>dnssec</th>\n      <th>domain_name</th>\n      <th>emails_1</th>\n      <th>emails_2</th>\n      <th>expiration_date_1</th>\n      <th>...</th>\n      <th>tech</th>\n      <th>referral_url</th>\n      <th>registrar_site</th>\n      <th>emails_7</th>\n      <th>entropy</th>\n      <th>dns_rec_a_cc</th>\n      <th>dns_rec_a_org</th>\n      <th>dns_rec_mx_cc</th>\n      <th>dns_rec_mx_org</th>\n      <th>malicious</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>434</th>\n      <td>altervista.org</td>\n      <td>True</td>\n      <td>CA;IT</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned</td>\n      <td>ALTERVISTA.ORG</td>\n      <td>domainabuse@tucows.com</td>\n      <td>abuse_reports@altervista.it</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.921928</td>\n      <td>de</td>\n      <td>hetzner online gmbh - contact role</td>\n      <td>de</td>\n      <td>hetzner online gmbh - contact role</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n<p>1 rows × 185 columns</p>\n</div>"
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[df.country=='CA;IT']"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "outputs": [],
+   "source": [
+    "df['l'] = df.country.apply(len)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "                domain  redacted               country creation_date_1  \\\n434     altervista.org      True                 CA;IT             NaN   \n682           zend.com      True  REDACTED FOR PRIVACY             NaN   \n928              gv.at     False               AUSTRIA             NaN   \n1115           lua.org      True                 BR;FR             NaN   \n1134   raspberrypi.org      True                 CA;GB             NaN   \n...                ...       ...                   ...             ...   \n6018     selltaxes.com     False              MALAYSIA             NaN   \n6019    inbiz-cons.com     False              MALAYSIA             NaN   \n6242     bablefiler.at     False                BRAZIL             NaN   \n6383  f1.bablefiler.at     False                BRAZIL             NaN   \n6424    bizneshear.com     False              MALAYSIA             NaN   \n\n     creation_date_2             dnssec                    domain_name  \\\n434              NaN           unsigned                 ALTERVISTA.ORG   \n682              NaN           unsigned                       ZEND.COM   \n928              NaN                NaN                          gv.at   \n1115             NaN  unsigned;Unsigned                LUA.ORG;lua.org   \n1134             NaN   signedDelegation                RASPBERRYPI.ORG   \n...              ...                ...                            ...   \n6018             NaN           unsigned    SELLTAXES.COM;selltaxes.com   \n6019             NaN           unsigned  INBIZ-CONS.COM;inbiz-cons.com   \n6242             NaN                NaN                  bablefiler.at   \n6383             NaN                NaN                  bablefiler.at   \n6424             NaN           unsigned  BIZNESHEAR.COM;bizneshear.com   \n\n                        emails_1  \\\n434       domainabuse@tucows.com   \n682                          NaN   \n928                          NaN   \n1115     abuse@support.gandi.net   \n1134      domainabuse@tucows.com   \n...                          ...   \n6018  compliance_abuse@webnic.cc   \n6019  compliance_abuse@webnic.cc   \n6242                         NaN   \n6383                         NaN   \n6424  compliance_abuse@webnic.cc   \n\n                                               emails_2    expiration_date_1  \\\n434                         abuse_reports@altervista.it                  NaN   \n682                                                 NaN                  NaN   \n928                                                 NaN                  NaN   \n1115  392cb661480a07691cadd1eedeca9241-845330@contac...                  NaN   \n1134                          support@mythic-beasts.com                  NaN   \n...                                                 ...                  ...   \n6018                    reg_19053889@whoisprotection.cc                  NaN   \n6019                    reg_19053886@whoisprotection.cc                  NaN   \n6242                                                NaN                  NaN   \n6383                                                NaN                  NaN   \n6424                    reg_18973698@whoisprotection.cc  2022-08-12 12:02:03   \n\n      ... referral_url registrar_site emails_7   entropy dns_rec_a_cc  \\\n434   ...          NaN            NaN      NaN  2.921928           de   \n682   ...          NaN            NaN      NaN  2.000000           us   \n928   ...          NaN            NaN      NaN  0.000000           na   \n1115  ...          NaN            NaN      NaN  1.584963           de   \n1134  ...          NaN            NaN      NaN  2.845351           us   \n...   ...          ...            ...      ...       ...          ...   \n6018  ...          NaN            NaN      NaN  2.503258           na   \n6019  ...          NaN            NaN      NaN  2.921928           us   \n6242  ...          NaN            NaN      NaN  2.721928           na   \n6383  ...          NaN            NaN      NaN  2.918296           na   \n6424  ...          NaN            NaN      NaN  3.121928           ro   \n\n                           dns_rec_a_org dns_rec_mx_cc  \\\n434   hetzner online gmbh - contact role            de   \n682                               fastly            us   \n928                                   na            na   \n1115  hetzner online gmbh - contact role            de   \n1134                    cloudflare, inc.            us   \n...                                  ...           ...   \n6018                                  na            na   \n6019                     namecheap, inc.            na   \n6242                                  na            na   \n6383                                  na            na   \n6424                    globalaxs de noc            na   \n\n                          dns_rec_mx_org malicious   l  \n434   hetzner online gmbh - contact role     False   5  \n682                microsoft corporation     False  20  \n928                                   na     False   7  \n1115  hetzner online gmbh - contact role     False   5  \n1134                          google llc     False   5  \n...                                  ...       ...  ..  \n6018                                  na      True   8  \n6019                                  na      True   8  \n6242                                  na      True   6  \n6383                                  na      True   6  \n6424                                  na      True   8  \n\n[69 rows x 186 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>domain</th>\n      <th>redacted</th>\n      <th>country</th>\n      <th>creation_date_1</th>\n      <th>creation_date_2</th>\n      <th>dnssec</th>\n      <th>domain_name</th>\n      <th>emails_1</th>\n      <th>emails_2</th>\n      <th>expiration_date_1</th>\n      <th>...</th>\n      <th>referral_url</th>\n      <th>registrar_site</th>\n      <th>emails_7</th>\n      <th>entropy</th>\n      <th>dns_rec_a_cc</th>\n      <th>dns_rec_a_org</th>\n      <th>dns_rec_mx_cc</th>\n      <th>dns_rec_mx_org</th>\n      <th>malicious</th>\n      <th>l</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>434</th>\n      <td>altervista.org</td>\n      <td>True</td>\n      <td>CA;IT</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned</td>\n      <td>ALTERVISTA.ORG</td>\n      <td>domainabuse@tucows.com</td>\n      <td>abuse_reports@altervista.it</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.921928</td>\n      <td>de</td>\n      <td>hetzner online gmbh - contact role</td>\n      <td>de</td>\n      <td>hetzner online gmbh - contact role</td>\n      <td>False</td>\n      <td>5</td>\n    </tr>\n    <tr>\n      <th>682</th>\n      <td>zend.com</td>\n      <td>True</td>\n      <td>REDACTED FOR PRIVACY</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned</td>\n      <td>ZEND.COM</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.000000</td>\n      <td>us</td>\n      <td>fastly</td>\n      <td>us</td>\n      <td>microsoft corporation</td>\n      <td>False</td>\n      <td>20</td>\n    </tr>\n    <tr>\n      <th>928</th>\n      <td>gv.at</td>\n      <td>False</td>\n      <td>AUSTRIA</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>gv.at</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>0.000000</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>False</td>\n      <td>7</td>\n    </tr>\n    <tr>\n      <th>1115</th>\n      <td>lua.org</td>\n      <td>True</td>\n      <td>BR;FR</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned;Unsigned</td>\n      <td>LUA.ORG;lua.org</td>\n      <td>abuse@support.gandi.net</td>\n      <td>392cb661480a07691cadd1eedeca9241-845330@contac...</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>1.584963</td>\n      <td>de</td>\n      <td>hetzner online gmbh - contact role</td>\n      <td>de</td>\n      <td>hetzner online gmbh - contact role</td>\n      <td>False</td>\n      <td>5</td>\n    </tr>\n    <tr>\n      <th>1134</th>\n      <td>raspberrypi.org</td>\n      <td>True</td>\n      <td>CA;GB</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>signedDelegation</td>\n      <td>RASPBERRYPI.ORG</td>\n      <td>domainabuse@tucows.com</td>\n      <td>support@mythic-beasts.com</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.845351</td>\n      <td>us</td>\n      <td>cloudflare, inc.</td>\n      <td>us</td>\n      <td>google llc</td>\n      <td>False</td>\n      <td>5</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>6018</th>\n      <td>selltaxes.com</td>\n      <td>False</td>\n      <td>MALAYSIA</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned</td>\n      <td>SELLTAXES.COM;selltaxes.com</td>\n      <td>compliance_abuse@webnic.cc</td>\n      <td>reg_19053889@whoisprotection.cc</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.503258</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>True</td>\n      <td>8</td>\n    </tr>\n    <tr>\n      <th>6019</th>\n      <td>inbiz-cons.com</td>\n      <td>False</td>\n      <td>MALAYSIA</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned</td>\n      <td>INBIZ-CONS.COM;inbiz-cons.com</td>\n      <td>compliance_abuse@webnic.cc</td>\n      <td>reg_19053886@whoisprotection.cc</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.921928</td>\n      <td>us</td>\n      <td>namecheap, inc.</td>\n      <td>na</td>\n      <td>na</td>\n      <td>True</td>\n      <td>8</td>\n    </tr>\n    <tr>\n      <th>6242</th>\n      <td>bablefiler.at</td>\n      <td>False</td>\n      <td>BRAZIL</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>bablefiler.at</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.721928</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>True</td>\n      <td>6</td>\n    </tr>\n    <tr>\n      <th>6383</th>\n      <td>f1.bablefiler.at</td>\n      <td>False</td>\n      <td>BRAZIL</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>bablefiler.at</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>2.918296</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>na</td>\n      <td>True</td>\n      <td>6</td>\n    </tr>\n    <tr>\n      <th>6424</th>\n      <td>bizneshear.com</td>\n      <td>False</td>\n      <td>MALAYSIA</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>unsigned</td>\n      <td>BIZNESHEAR.COM;bizneshear.com</td>\n      <td>compliance_abuse@webnic.cc</td>\n      <td>reg_18973698@whoisprotection.cc</td>\n      <td>2022-08-12 12:02:03</td>\n      <td>...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>3.121928</td>\n      <td>ro</td>\n      <td>globalaxs de noc</td>\n      <td>na</td>\n      <td>na</td>\n      <td>True</td>\n      <td>8</td>\n    </tr>\n  </tbody>\n</table>\n<p>69 rows × 186 columns</p>\n</div>"
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[df.l>2]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   }
  ],
  "metadata": {

--- a/src/scripts/artemis_data.py
+++ b/src/scripts/artemis_data.py
@@ -163,6 +163,16 @@ def set_updated_date(row):
     return row
 
 
+def set_expiration_date(row):
+    mask = row[expiration_date_cols].notnull()
+    if mask.any():
+        latest_expiration_date = row[expiration_date_cols][mask].max()
+    else:
+        latest_expiration_date = pd.NaT
+    row[expiration_date_cols[0]] = latest_expiration_date
+    return row
+
+
 def clean_data(df):
     clean_df = df.copy(deep=True)  # make a copy of the df
     clean_df = clean_df.dropna(subset='redacted')  # drop any where redacted is NaN; those don't contain whois record
@@ -183,4 +193,8 @@ def clean_data(df):
     updated_date_cols_to_drop.remove(updated_date_cols[0])
     clean_df = clean_df.drop(columns=updated_date_cols_to_drop)
     clean_df['days_since_update'] = clean_df.updated_date.apply(calc_days_since)
+    clean_df = clean_df.apply(set_expiration_date, axis=1)
+    expiration_date_cols_to_drop = copy.deepcopy(expiration_date_cols)
+    expiration_date_cols_to_drop.remove(expiration_date_cols[0])
+    clean_df = clean_df.drop(columns=expiration_date_cols_to_drop)
     return clean_df

--- a/src/scripts/artemis_data.py
+++ b/src/scripts/artemis_data.py
@@ -4,6 +4,7 @@ import json
 
 creation_date_cols = ['creation_date', 'creation_date_1', 'creation_date_2', 'creation_date_3', 'creation_date_4']
 updated_date_cols = ['updated_date', 'updated_date_1', 'updated_date_2', 'updated_date_3', 'updated_date_4']
+expiration_date_cols = ['expiration_date', 'expiration_date_1', 'expiration_date_2']
 bad_countries = []
 
 
@@ -168,7 +169,7 @@ def clean_data(df):
     clean_df['country'] = clean_df.country.fillna("ZZ")  # ZZ is no country
     clean_df['country'] = clean_df.country.apply(clean_country)
     print(f"{len(bad_countries)} records had countries that are ambiguous: {bad_countries}")
-    for col in creation_date_cols + updated_date_cols:
+    for col in creation_date_cols + updated_date_cols + expiration_date_cols:
         clean_df[col] = clean_df[col].apply(clean_dates)
     clean_df['days_between_creations'] = pd.NA
     clean_df = clean_df.apply(set_creation_date, axis=1)

--- a/src/scripts/artemis_data.py
+++ b/src/scripts/artemis_data.py
@@ -63,11 +63,50 @@ def change_entropy_data(obj):
 
 
 def change_ip_data(obj):
-    if len(list(obj.values()))>2:
+    if len(list(obj.values())) > 2:
         print(obj)
     domain = list(obj.keys())[0]
-    new_obj = { "domain": domain }
+    new_obj = {"domain": domain}
     for rec_type, records in obj[domain].items():
         for k, v in records.items():
             new_obj[f"dns_rec_{rec_type.lower()}_{k.lower()}"] = v.lower()
     return new_obj
+
+
+country_map = {
+    "MALAYSIA":                  "MY",
+    "BRAZIL":                    "BR",
+    "FINLAND":                   "FI",
+    "SPAIN":                     "ES",
+    "GERMANY":                   "DE",
+    "ROK":                       "KR",
+    "KOREA (THE REPUBLIC OF)":   "KR",
+    "RUSSIAN FEDERATION (THE)":  "RU",
+    "AUSTRIA":                   "AT",
+    "NETHERLANDS (THE)":         "NL",
+    "PORTUGAL":                  "PT",
+    "ARMENIA":                   "AM"
+}
+
+def clean_country(country):
+    c = country.upper()
+    if len(country) > 2:
+        if ";" in c:
+            print(c)
+        elif "UNITED STATES" in c:
+            c = "US"
+        elif "REDACTED" in c:
+            c = "XX" # country ws redacted
+        elif c in country_map.keys():
+            c = country_map[c]
+        else:
+            print(country)
+    return c
+
+
+def clean_data(df):
+    clean_df = df.copy(deep=True)  # make a copy of the df
+    clean_df = clean_df.dropna(subset='redacted')  # drop any where redacted is NaN; those don't contain whois record
+    clean_df['country'] = clean_df.country.fillna("ZZ")  # ZZ is no country
+    clean_df['country'] = clean_df.country.apply(clean_country)
+    return clean_df

--- a/src/scripts/artemis_data.py
+++ b/src/scripts/artemis_data.py
@@ -197,4 +197,7 @@ def clean_data(df):
     expiration_date_cols_to_drop = copy.deepcopy(expiration_date_cols)
     expiration_date_cols_to_drop.remove(expiration_date_cols[0])
     clean_df = clean_df.drop(columns=expiration_date_cols_to_drop)
+    clean_df['days_until_expiration'] = clean_df.expiration_date.apply(
+                        lambda dt: pd.NA if pd.isna(dt) else (dt - pd.Timestamp.today().date()).days
+    )
     return clean_df

--- a/src/scripts/artemis_data.py
+++ b/src/scripts/artemis_data.py
@@ -3,6 +3,7 @@ import pandas as pd
 import json
 
 creation_date_cols = ['creation_date', 'creation_date_1', 'creation_date_2', 'creation_date_3', 'creation_date_4']
+updated_date_cols = ['updated_date', 'updated_date_1', 'updated_date_2', 'updated_date_3', 'updated_date_4']
 
 
 def process(row):
@@ -151,11 +152,11 @@ def clean_data(df):
     clean_df = clean_df.dropna(subset='redacted')  # drop any where redacted is NaN; those don't contain whois record
     clean_df['country'] = clean_df.country.fillna("ZZ")  # ZZ is no country
     clean_df['country'] = clean_df.country.apply(clean_country)
-    for col in creation_date_cols:
+    for col in creation_date_cols + updated_date_cols:
         clean_df[col] = clean_df[col].apply(clean_dates)
     clean_df['days_between_creations'] = pd.NA
     clean_df = clean_df.apply(set_creation_date, axis=1)
-    creation_date_cols_to_drop = creation_date_cols.copy()
+    creation_date_cols_to_drop = copy.deepcopy(creation_date_cols)
     creation_date_cols_to_drop.remove('creation_date')
     clean_df = clean_df.drop(columns=creation_date_cols_to_drop)
     clean_df['days_since_creation'] = clean_df.creation_date.apply(calc_days_since_creation)

--- a/src/scripts/make_dataset.py
+++ b/src/scripts/make_dataset.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from dotenv import find_dotenv, load_dotenv
 
-from artemis_data import load_datafile
+from artemis_data import load_datafile, clean_data
 
 whois_data_file_suffix = '_whois_data.txt'
 entropy_data_file_suffix = '_entropy_data.txt'
@@ -39,7 +39,9 @@ def main(input_filepath, output_filepath):
     malicious_merged_df = pd.merge(malicious_merged_df, malicious_ip_df, on='domain')
     malicious_merged_df['malicious'] = True
     logger.info("Concatenating malicious and benign data files.")
-    final_df = pd.concat([benign_merged_df, malicious_merged_df])
+    interim_df = pd.concat([benign_merged_df, malicious_merged_df])
+    logger.info("Cleaning combined dataframe.")
+    final_df = clean_data(interim_df)
     outfile = f"{output_filepath}/{final_data_filename}"
     final_df.to_csv(outfile, index=False)
     logger.info(f"Wrote merged datafile to {outfile}.")

--- a/src/scripts/make_dataset.py
+++ b/src/scripts/make_dataset.py
@@ -13,6 +13,7 @@ entropy_data_file_suffix = '_entropy_data.txt'
 ip_data_file_suffix = '_ip_data.txt'
 final_data_filename = 'whois_data.csv'
 
+
 @click.command()
 @click.argument('input_filepath', type=click.Path(exists=True), required=False, )
 @click.argument('output_filepath', type=click.Path())
@@ -22,7 +23,7 @@ def main(input_filepath, output_filepath):
     """
     logger = logging.getLogger(__name__)
     logger.info('Making final data set from raw data.')
-    #TODO: Finish data processing script
+    # TODO: Finish data processing script
 
     logger.info(f"Loading benign data from {input_filepath}.")
     benign_domain_df = load_datafile(f"{input_filepath}/benign{whois_data_file_suffix}", filetype='whois')
@@ -46,6 +47,7 @@ def main(input_filepath, output_filepath):
     final_df.to_csv(outfile, index=False)
     logger.info(f"Wrote merged datafile to {outfile}.")
     sys.exit()
+
 
 if __name__ == '__main__':
     log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'


### PR DESCRIPTION
This PR cleans the country field, and the date fields (`creation_date, updated_date, and expiration_date`), sets `<field>_date` as the primary (and only) date field for each of the three by dropping `field_date_X` fields. It also adds `days_since_creation,  days_between_creations, days_since_update, days_between_updates, and days_until_expiration` fields.

- clean_country will set the country to the two-letter country code as defined in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), with the following additions
-  Country code XX represents records where the country was redacted.
-  Country code ZZ represents records where a country was not available (NaN). 
- clean_dates sets all creation_date fields to be a date (not datetime), removes time from the data, and uses pandas.NaT to represent NaN time fields. 
- set_creation_date sets the `creation_date` field to be the latest creation date, and adds two fields:
- `days_between_creations` which represents the number of days between the latest and earliest creation dates. This helps us track if a domain has been recreated.
- `days_since_creation` lets us track how long it's been since the domain was created.
- Same again for set_updated_date and set_expiration_date, with relevant added fields. One difference is that 'days_until_expiration` tracks how many days until the record is set to expire. 
